### PR TITLE
Patch11 forpullreq

### DIFF
--- a/applications/callflow/src/module/cf_eavesdrop.erl
+++ b/applications/callflow/src/module/cf_eavesdrop.erl
@@ -90,7 +90,7 @@ eavesdrop_a_channel(Channels, Call, Data) ->
         {[], [RemoteChannel | _Remote]} ->
             lager:info("no calls on my media server, trying redirect to ~s", [kz_json:get_ne_binary_value(<<"node">>, RemoteChannel)]),
             Contact = erlang:iolist_to_binary(["sip:", kapps_call:request(Call)]),
-            kapps_call_command:redirect_to_node(Contact, kz_json:get_ne_binary_value(<<"node">>, RemoteChannel), Call);
+            kapps_call_command:redirect_to_node_eavesdrop(Contact, kz_json:get_ne_binary_value(<<"node">>, RemoteChannel), Call);
         {[LocalChannel | _Cs], _} ->
             lager:info("found a call (~s) on my media server", [kz_json:get_ne_binary_value(<<"uuid">>, LocalChannel)]),
             eavesdrop_call(LocalChannel, Call, Data)

--- a/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
+++ b/applications/ecallmgr/src/call_cmd/ecallmgr_call_command.erl
@@ -1542,20 +1542,16 @@ set_init_whisper_mode(Node, UUID, Mode) ->
 
 -spec eavesdrop_bridge_both(atom(), kz_term:ne_binary())  -> 'ok'.
 eavesdrop_bridge_both(Node, UUID) ->
-    _ = ecallmgr_util:send_cmd(Node, UUID, "unset", "eavesdrop_bridge_aleg"),
     _ = ecallmgr_util:send_cmd(Node, UUID, "set", "eavesdrop_bridge_aleg=true"),
-    _ = ecallmgr_util:send_cmd(Node, UUID, "unset", "eavesdrop_bridge_bleg"),
     _ = ecallmgr_util:send_cmd(Node, UUID, "set", "eavesdrop_bridge_bleg=true"),
     'ok'.
     
 -spec eavesdrop_whisper_a(atom(), kz_term:ne_binary())  -> 'ok'.
 eavesdrop_whisper_a(Node, UUID) ->
-    _ = ecallmgr_util:send_cmd(Node, UUID, "unset", "eavesdrop_whisper_aleg"),
     _ = ecallmgr_util:send_cmd(Node, UUID, "set", "eavesdrop_whisper_aleg=true"),
     'ok'.
 
 -spec eavesdrop_whisper_b(atom(), kz_term:ne_binary())  -> 'ok'.
 eavesdrop_whisper_b(Node, UUID) ->
-    _ = ecallmgr_util:send_cmd(Node, UUID, "unset", "eavesdrop_whisper_bleg"),
     _ = ecallmgr_util:send_cmd(Node, UUID, "set", "eavesdrop_whisper_bleg=true"),
     'ok'.

--- a/core/kazoo_call/src/kapps_call_command.erl
+++ b/core/kazoo_call/src/kapps_call_command.erl
@@ -41,6 +41,7 @@
 -export([redirect/2
         ,redirect/3
         ,redirect_to_node/3
+        ,redirect_to_node_eavesdrop/3
         ]).
 -export([answer/1, answer_now/1
         ,hangup/1, hangup/2
@@ -793,12 +794,27 @@ redirect_to_node(Contact, Node, Call) ->
     lager:debug("redirect ~s to ~s", [Contact, Node]),
     Command = [{<<"Redirect-Contact">>, Contact}
               ,{<<"Redirect-Node">>, Node}
+              ,{<<"Application-Name">>, <<"redirect">>}
+              ],
+    send_command(Command, Call),
+    timer:sleep(2 * ?MILLISECONDS_IN_SECOND),
+    'ok'.
+
+%%------------------------------------------------------------------------------
+%% @doc Create a redirect request to Node for eavesdrop.
+%% @end
+%%------------------------------------------------------------------------------
+-spec redirect_to_node_eavesdrop(kz_term:ne_binary(), kz_term:api_binary(), kapps_call:call()) -> 'ok'.
+redirect_to_node_eavesdrop(Contact, Node, Call) ->
+    lager:debug("redirect ~s to ~s", [Contact, Node]),
+    Command = [{<<"Redirect-Contact">>, Contact}
               ,{<<"Redirect-Server">>, Node}
               ,{<<"Application-Name">>, <<"redirect">>}
               ],
     send_command(Command, Call),
     timer:sleep(2 * ?MILLISECONDS_IN_SECOND),
     'ok'.
+
 
 %%------------------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
1) deleted unsets
its about(lazedo: expensive operations here)
and
2) created own function for redirect_to_node_eavesdrop
its about(lazedo: other than that, for master we may actually split the redirect from eavesdrop.
the redirect should be handled at route_req in callflow or at cf_module_util (to be used by callflow actions) where)